### PR TITLE
Modify connection timeout process

### DIFF
--- a/gear/__init__.py
+++ b/gear/__init__.py
@@ -1204,6 +1204,7 @@ class BaseClient(BaseClientServer):
 
     def _checkTimeout(self, start_time, timeout):
         if time.time() - start_time > timeout:
+            self.connections_condition.release()
             raise TimeoutError()
 
     def waitForServer(self, timeout=None):


### PR DESCRIPTION
When connect gearman server timeout, it's necessary to
release lock before raising a exception(otherwise the client may be dead locked).

Signed-off-by: shangxdy <shang.xiaodong@zte.com.cn>